### PR TITLE
Change lbvserver from required to optional

### DIFF
--- a/citrixadc/resource_citrixadc_service.go
+++ b/citrixadc/resource_citrixadc_service.go
@@ -295,7 +295,7 @@ func resourceCitrixAdcService() *schema.Resource {
 
 			"lbvserver": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"lbmonitor": &schema.Schema{


### PR DESCRIPTION
This could resolve #91 - An issue where you are unable to create a service unless you specify an lbvserver to bind it to. Binding an lbvserver is not a requirement to creating a service, in fact it is not even an option when creating a service.