### PR TITLE
snmpcommunity possible values and validation

### DIFF
--- a/docs/resources/snmpcommunity.md
+++ b/docs/resources/snmpcommunity.md
@@ -20,7 +20,7 @@ resource "citrixadc_snmpcommunity" "tf_snmpcommunity" {
 ## Argument Reference
 
 * `communityname` - (Required) The SNMP community string. Can consist of 1 to 31 characters that include uppercase and lowercase letters,numbers and special characters.  The following requirement applies only to the Citrix ADC CLI: If the string includes one or more spaces, enclose the name in double or single quotation marks (for example, "my string" or 'my string').
-* `permissions` - (Optional) The SNMP V1 or V2 query-type privilege that you want to associate with this SNMP community.
+* `permissions` - (Optional) The SNMP V1 or V2 query-type privilege that you want to associate with this SNMP community. Possible values: [ GET, GET_NEXT, GET_BULK, SET, ALL ]
 
 
 ## Attribute Reference


### PR DESCRIPTION
This PR solves #1019

Additionally, the possible values for permissions are now validated during plan phase via a validatefunc, and via the statefunc we assure that state is store in uppercase to prevent recreation because of caps sensitivity.