### PR TITLE
Escape URL chars in key for policy stringmap bindings

### DIFF
--- a/citrixadc/resource_citrixadc_policystringmap_pattern_binding.go
+++ b/citrixadc/resource_citrixadc_policystringmap_pattern_binding.go
@@ -1,9 +1,10 @@
 package citrixadc
 
 import (
+	"net/url"
+
 	"github.com/citrix/adc-nitro-go/resource/config/policy"
 	"github.com/citrix/adc-nitro-go/service"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"fmt"
@@ -133,7 +134,7 @@ func deletePolicystringmap_pattern_bindingFunc(d *schema.ResourceData, meta inte
 	idSlice := strings.SplitN(bindingId, ",", 2)
 
 	name := idSlice[0]
-	key := idSlice[1]
+	key := url.PathEscape(idSlice[1])
 
 	args := make([]string, 0)
 	args = append(args, fmt.Sprintf("key:%s", key))


### PR DESCRIPTION
This change fixes issue #1018 specificly by implementing escape function for the key. An alternative but more complex solution would be to perform the escapes directly in DeleteReourceWithArgs and possibly others in the client.

I can make a separate pull for that. But that one would require more testing for obvious reasons.

Signed-off-by: Martin Nygaard Jensen <martin@ravager.dk>