### PR TITLE
Added ForceNew to sslprofiletype argument

### DIFF
--- a/citrixadc/resource_citrixadc_sslprofile.go
+++ b/citrixadc/resource_citrixadc_sslprofile.go
@@ -357,6 +357,7 @@ func resourceCitrixAdcSslprofile() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"sslredirect": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Added a ForceNew property to sslprofile sslprofiletype. This causes a new profile to be created if the type changes, as this cannot be modified after creating the profile.

This PR fixes issue #1081.

Signed-off-by: Martin Nygaard Jensen <martin@ravager.dk>