### PR TITLE
fix: appfwprofile_sqlinjection_binding

### DIFF
--- a/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding.go
+++ b/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding.go
@@ -209,8 +209,12 @@ func deleteAppfwprofile_sqlinjection_bindingFunc(d *schema.ResourceData, meta in
 	args["sqlinjection"] = sqlinjection
 	args["formactionurl_sql"] = url.QueryEscape(d.Get("formactionurl_sql").(string))
 	args["as_scan_location_sql"] = d.Get("as_scan_location_sql").(string)
-	args["as_value_type_sql"] = d.Get("as_value_type_sql").(string)
-	args["as_value_expr_sql"] = d.Get("as_value_expr_sql").(string)
+	if val, ok := d.GetOk("as_value_type_sql"); ok {
+		args["as_value_type_sql"] = val.(string)
+	}
+	if val, ok := d.GetOk("as_value_expr_sql"); ok {
+		args["as_value_expr_sql"] = val.(string)
+	}
 
 	err := client.DeleteResourceWithArgsMap(service.Appfwprofile_sqlinjection_binding.Type(), appFwName, args)
 	if err != nil {

--- a/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding.go
+++ b/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding.go
@@ -209,6 +209,8 @@ func deleteAppfwprofile_sqlinjection_bindingFunc(d *schema.ResourceData, meta in
 	args["sqlinjection"] = sqlinjection
 	args["formactionurl_sql"] = url.QueryEscape(d.Get("formactionurl_sql").(string))
 	args["as_scan_location_sql"] = d.Get("as_scan_location_sql").(string)
+	args["as_value_type_sql"] = d.Get("as_value_type_sql").(string)
+	args["as_value_expr_sql"] = d.Get("as_value_expr_sql").(string)
 
 	err := client.DeleteResourceWithArgsMap(service.Appfwprofile_sqlinjection_binding.Type(), appFwName, args)
 	if err != nil {

--- a/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding_test.go
+++ b/citrixadc/resource_citrixadc_appfwprofile_sqlinjection_binding_test.go
@@ -69,6 +69,51 @@ const testAccAppfwprofile_sqlinjection_binding_basic = `
 	}
 `
 
+const testAccAppfwprofile_sqlinjection_binding_as_value_type_sql = `
+	resource citrixadc_appfwprofile_sqlinjection_binding demo_as_value_type_sql_binding {
+		name = citrixadc_appfwprofile.demo_appfw_as_value_type_sql.name
+		sqlinjection= "demo_binding"
+		as_scan_location_sql= "HEADER"
+		as_value_type_sql= "Keyword"
+		as_value_expr_sql= "example1"
+		formactionurl_sql= "www.example.com"
+		state= "ENABLED"
+		isregex_sql= "NOTREGEX"
+	}
+
+	resource citrixadc_appfwprofile demo_appfw_as_value_type_sql {
+		name = "demo_appfw_as_value_type_sql"
+		bufferoverflowaction = ["none"]
+		contenttypeaction = ["none"]
+		cookieconsistencyaction = ["none"]
+		creditcard = ["none"]
+		creditcardaction = ["none"]
+		crosssitescriptingaction = ["none"]
+		csrftagaction = ["none"]
+		denyurlaction = ["none"]
+		dynamiclearning = ["none"]
+		fieldconsistencyaction = ["none"]
+		fieldformataction = ["none"]
+		fileuploadtypesaction = ["none"]
+		inspectcontenttypes = ["none"]
+		jsondosaction = ["none"]
+		jsonsqlinjectionaction = ["none"]
+		jsonxssaction = ["none"]
+		multipleheaderaction = ["none"]
+		sqlinjectionaction = ["none"]
+		starturlaction = ["none"]
+		type = ["HTML"]
+		xmlattachmentaction = ["none"]
+		xmldosaction = ["none"]
+		xmlformataction = ["none"]
+		xmlsoapfaultaction = ["none"]
+		xmlsqlinjectionaction = ["none"]
+		xmlvalidationaction = ["none"]
+		xmlwsiaction = ["none"]
+		xmlxssaction = ["none"]
+	}
+`
+
 func TestAccAppfwprofile_sqlinjection_binding_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,6 +127,17 @@ func TestAccAppfwprofile_sqlinjection_binding_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_binding", "name", "demo_appfwprofile"),
 					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_binding", "as_scan_location_sql", "HEADER"),
 					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_binding", "formactionurl_sql", "www.example.com"),
+				),
+			},
+			{
+				Config: testAccAppfwprofile_sqlinjection_binding_as_value_type_sql,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppfwprofile_sqlinjection_bindingExist("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", nil),
+					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", "name", "demo_appfw_as_value_type_sql"),
+					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", "as_scan_location_sql", "HEADER"),
+					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", "formactionurl_sql", "www.example.com"),
+					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", "as_value_type_sql", "Keyword"),
+					resource.TestCheckResourceAttr("citrixadc_appfwprofile_sqlinjection_binding.demo_as_value_type_sql_binding", "as_value_expr_sql", "example1"),
 				),
 			},
 		},


### PR DESCRIPTION
Updating binding fails.

Consider this resource:

```hcl
resource "citrixadc_appfwprofile_sqlinjection_binding" "this" {
  name                 = citrixadc_appfwprofile.this.name
  sqlinjection         = "field"
  formactionurl_sql    = "https://example"
  as_scan_location_sql = "FORMFIELD"
  isregex_sql          = "NOTREGEX"
  as_value_type_sql    = "Keyword"
  as_value_expr_sql    = "example1"
  isvalueregex_sql     = "NOTREGEX"
  state                = "ENABLED"
}
```

After changing a value like this:

```hcl
resource "citrixadc_appfwprofile_sqlinjection_binding" "this" {
  name                 = citrixadc_appfwprofile.this.name
  sqlinjection         = "field"
  formactionurl_sql    = "https://example"
  as_scan_location_sql = "FORMFIELD"
  isregex_sql          = "NOTREGEX"
  as_value_type_sql    = "Keyword"
  as_value_expr_sql    = "example2"
  isvalueregex_sql     = "NOTREGEX"
  state                = "ENABLED"
}
```

The update fails with 

```
Error: [INFO] delete failed: 599 Netscaler specific error ({ "errorcode": 3130, "message": "No such SQLInjection check", "severity": "ERROR" })
```

Here is the nitro log for this update:

```
Command "unbind appfw profile appfw-profile-tf-tfi-fbt-smaragd-tcm-webcheck-htmlwaf -SQLInjection sqlinjection "
https://sqlinjection"
-location FORMFIELD -RuleType ALLOW" - Status "ERROR: No such SQLInjection check"
```

The problem is that in the delete process specifying the sqlinjection field is not sufficient for identifying the rule.

This PR adds fields to be able to apply the changes in the example above.

This may not be sufficient for all scenarios and also applies for other resources like `appfwprofile_crosssitescripting_binding`. We are currently testing those resources and will add more fixes accordingly.