### PR TITLE
Clears nsrpcnode if it has been manually deleted

### DIFF
--- a/citrixadc/resource_citrixadc_nsrpcnode.go
+++ b/citrixadc/resource_citrixadc_nsrpcnode.go
@@ -96,6 +96,13 @@ func readNsrpcnodeFunc(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	if len(dataArray) == 0 {
+		log.Printf("[DEBUG] citrixadc-provider: Failed to find nsrpcnode %s", nsrpcnodeIpaddress)
+		log.Printf("[WARN] citrixadc-provider: Clearing nsrpcnode state %s", nsrpcnodeIpaddress)
+		d.SetId("")
+		return nil
+	}
+
 	if len(dataArray) != 1 {
 		return fmt.Errorf("[ERROR] Read multiple nsprcnode instances %v", dataArray)
 	}


### PR DESCRIPTION
Closes issue #1187.

By checking if the dataarray contains 0 elements and then clearing the state, the issue is resolved.