### PR TITLE
Create SSL RSA key files #1176

### DIFF
--- a/citrixadc/provider.go
+++ b/citrixadc/provider.go
@@ -850,6 +850,7 @@ func providerResources() map[string]*schema.Resource {
 		"citrixadc_spilloverpolicy":                                               resourceCitrixAdcSpilloverpolicy(),
 		"citrixadc_sslcert":                                                       resourceCitrixAdcSslcert(),
 		"citrixadc_sslcertreq":                                                    resourceCitrixAdcSslcertreq(),
+		"citrixadc_sslrsakey":                                                     resourceCitrixAdcSslrsakey(),
 		"citrixadc_snmptrap_snmpuser_binding":                                     resourceCitrixAdcSnmptrap_snmpuser_binding(),
 		"citrixadc_lbmetrictable_metric_binding":                                  resourceCitrixAdcLbmetrictable_metric_binding(),
 		"citrixadc_videooptimizationdetectionaction":                              resourceCitrixAdcVideooptimizationdetectionaction(),

--- a/citrixadc/resource_citrixadc_sslrsakey.go
+++ b/citrixadc/resource_citrixadc_sslrsakey.go
@@ -1,0 +1,103 @@
+package citrixadc
+
+import (
+	"github.com/citrix/adc-nitro-go/resource/config/ssl"
+
+	"github.com/citrix/adc-nitro-go/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"log"
+)
+
+func resourceCitrixAdcSslrsakey() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+		Create:        createSslrsakeyFunc,
+		Read:          schema.Noop,
+		Delete:        schema.Noop,
+		Schema: map[string]*schema.Schema{
+			"bits": {
+				Type:     schema.TypeInt,
+				Required: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"aes256": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			}, "des": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"des3": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"exponent": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"keyfile": {
+				Type:     schema.TypeString,
+				Required: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"keyform": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"pkcs8": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: false,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  false,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func createSslrsakeyFunc(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]  citrixadc-provider: In createSslrsakeyFunc")
+	client := meta.(*NetScalerNitroClient).client
+
+	sslrsakeyName := resource.PrefixedUniqueId("tf-sslrsakey-")
+	sslrsakey := ssl.Sslrsakey{
+		Bits:     d.Get("bits").(int),
+		Des:      d.Get("des").(bool),
+		Des3:     d.Get("des3").(bool),
+		Aes256:   d.Get("aes256").(bool),
+		Pkcs8:    d.Get("pkcs8").(bool),
+		Password: d.Get("password").(string),
+		Exponent: d.Get("exponent").(string),
+		Keyfile:  d.Get("keyfile").(string),
+		Keyform:  d.Get("keyform").(string),
+	}
+
+	err := client.ActOnResource(service.Sslrsakey.Type(), &sslrsakey, "create")
+	if err != nil {
+		return err
+	}
+
+	d.SetId(sslrsakeyName)
+
+	return nil
+}

--- a/citrixadc/resource_citrixadc_sslrsakey_test.go
+++ b/citrixadc/resource_citrixadc_sslrsakey_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 Citrix Systems, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package citrixadc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const testAccSslrsakey_basic = `
+
+	resource "citrixadc_systemfile" "tf_file" {
+		filename 	 = "key1.pem"
+		filelocation = "/nsconfig/ssl/"
+		filecontent  = "hello"
+	}
+	resource "citrixadc_sslrsakey" "tf_sslrsakey" {
+		reqfile          = "/nsconfig/ssl/test-ca.csr"
+		keyfile          = "/nsconfig/ssl/key1.pem"
+		countryname      = "in"
+		statename        = "kar"
+		organizationname = "xyz"
+		depends_on = [citrixadc_systemfile.tf_file]
+	}
+`
+
+func TestAccSslrsakey_basic(t *testing.T) {
+	t.Skip("TODO: Need to find a way to test this resource!")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSslrsakey_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSslrsakeyExist("citrixadc_sslrsakey.tf_sslrsakey", nil),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSslrsakeyExist(n string, id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sslrsakey name is set")
+		}
+
+		if id != nil {
+			if *id != "" && *id != rs.Primary.ID {
+				return fmt.Errorf("Resource ID has changed!")
+			}
+
+			*id = rs.Primary.ID
+		}
+		return nil
+	}
+}

--- a/docs/resources/sslrsakey.md
+++ b/docs/resources/sslrsakey.md
@@ -1,0 +1,39 @@
+---
+subcategory: "SSL"
+---
+
+# Resource: sslrsakey
+
+The sslrsakey resource is used to create ssl rsakey file.
+
+
+## Example usage
+
+```hcl
+resource "citrixadc_sslrsakey" "tf_sslrsakey" {
+  keyfile          = "/nsconfig/ssl/key1.pem"
+  bits             = 2048
+  aes256           = true
+  password         = "MySuperSecretPassword"
+}
+```
+
+
+## Argument Reference
+
+* `keyfile` - (Required) Name for and, optionally, path to the RSA key. /nsconfig/ssl/ is the default path. Maximum length =  63
+* `bits` - (Required) Size, in bits, of the RSA key. Minimum value: 512 Maximum value: 4096
+* `exponent` - (Optional) Public exponent for the RSA key. The exponent is part of the cipher algorithm and is required for creating the RSA key.  Possible values: 3, F4 Default value: F4
+* `keyform` - (Optional) Format in which the key is stored on the appliance. Possible values: [ DER, PEM ] Default value: PEM
+* `aes256` - (Optional) Encrypt the generated RSA key by using the AES algorithm.
+* `des` - (Optional) Encrypt the generated RSA key by using the DES algorithm.
+* `des3` - (Optional) Encrypt the generated RSA key by using the Triple-DES algorithm.
+* `password` - (Optional) Pass phrase to use for encryption if AES256, DES or DES3 option is selected. Maximum value: 31
+* `pkcs8` - (Optional) Create the private key in PKCS#8 format.
+
+## Attribute Reference
+
+In addition to the arguments, the following attributes are available:
+
+* `id` - The id of the sslrsakey. It is a unique string prefixed with "tf-sslrsakey-"
+


### PR DESCRIPTION
This pull request implements creating RSA keys on the netscaler, as requested in issue #1176.   It implements a new citrixadc_sslrsakey terraform resource. No existing resource is changed.
Implementation of ECSDA keys is not included, but should be fairly straight forward to do.
