### PR TITLE
Add query_args argument to nitro_info #1178

### DIFF
--- a/citrixadc/data_source_citrixadc_nitro_info.go
+++ b/citrixadc/data_source_citrixadc_nitro_info.go
@@ -22,6 +22,11 @@ func dataSourceCitrixAdcNitroInfo() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"query_args": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
 			"primary_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -78,6 +83,11 @@ func dataSourceCitrixAdcNitroInfoBindingListRead(d *schema.ResourceData, meta in
 	client := meta.(*NetScalerNitroClient).client
 	workflowMap := d.Get("workflow").(map[string]interface{})
 	primaryId := d.Get("primary_id").(string)
+	argsMap := make(map[string]string)
+	queryArgs := d.Get("query_args").(map[string]interface{})
+	for k, v := range queryArgs {
+		argsMap[k] = v.(string)
+	}
 	missingErrorCode, err := strconv.Atoi(workflowMap["bound_resource_missing_errorcode"].(string))
 	if err != nil {
 		return err
@@ -86,6 +96,7 @@ func dataSourceCitrixAdcNitroInfoBindingListRead(d *schema.ResourceData, meta in
 		ResourceType:             workflowMap["endpoint"].(string),
 		ResourceName:             primaryId,
 		ResourceMissingErrorCode: missingErrorCode,
+		ArgsMap:                  argsMap,
 	}
 
 	dataArr, err := client.FindResourceArrayWithParams(findParams)
@@ -128,6 +139,11 @@ func dataSourceCitrixAdcNitroInfoObjectByNameRead(d *schema.ResourceData, meta i
 	client := meta.(*NetScalerNitroClient).client
 	workflowMap := d.Get("workflow").(map[string]interface{})
 	primaryId := d.Get("primary_id").(string)
+	argsMap := make(map[string]string)
+	queryArgs := d.Get("query_args").(map[string]interface{})
+	for k, v := range queryArgs {
+		argsMap[k] = v.(string)
+	}
 	missingErrorCode, err := strconv.Atoi(workflowMap["bound_resource_missing_errorcode"].(string))
 	if err != nil {
 		return err
@@ -136,6 +152,7 @@ func dataSourceCitrixAdcNitroInfoObjectByNameRead(d *schema.ResourceData, meta i
 		ResourceType:             workflowMap["endpoint"].(string),
 		ResourceName:             primaryId,
 		ResourceMissingErrorCode: missingErrorCode,
+		ArgsMap:                  argsMap,
 	}
 
 	dataArr, err := client.FindResourceArrayWithParams(findParams)

--- a/docs/data-sources/nitro_info.md
+++ b/docs/data-sources/nitro_info.md
@@ -40,6 +40,23 @@ output "list_output" {
 output "object_output" {
     value = [ for item in data.citrixadc_nitro_info.sample.nitro_list: item.object ]
 }
+
+# Fetch the content of a file using query_args:
+data "citrixadc_nitro_info "my_file" {
+    workflow = {
+        lifecycle                        = "object_by_name"
+        endpoint                         = "systemfile"
+        bound_resource_missing_errorcode = "3441"
+    }
+    query_args = {
+        filename    = "my_file_name"
+        filecondent = urlencode("/my/file/path")
+    }
+}
+
+output "my_file" {
+    value = data.citrixadc_nitro_info.my_file.nitro_object.filecontent
+}
 ```
 
 ## Argument Reference
@@ -56,6 +73,7 @@ output "object_output" {
 
     A list of such workflows can be found in the github repository example folder for the `nitro_info` data source.
 
+* `query_args` - (Optional) A dictionary of query arguments that will be included when performing the request to the NITRO `endpoint` url.
 * `primary_id` - (Optional) Value for the primary id of the nitro endpoint.
 * `secondary_id` - (Optional) Value for the secondary id of the nitro endpoint.
 


### PR DESCRIPTION
This pull request adds a new "query_args" argument to the citrixadc_nitro_info data source, as requested in issue #1178.  The value of query_args is a map with key/value pairs that, when specified, will be added as query string key=value pairs when making the request to the workflow endpoint.  

Logically I would have preferred that the new argument was part of the lifecycle argument, alongside its endpoint key.  But I was unable get the go framework to accept a map as the value of a query_args key in workflow.
