### PR TITLE
Replace non-constant format string in t.Errorf with a constant format…

### DIFF
--- a/citrixadc/resource_citrixadc_authenticationsamlidpprofile_test.go
+++ b/citrixadc/resource_citrixadc_authenticationsamlidpprofile_test.go
@@ -136,7 +136,7 @@ func doSslPrecheckforsamlidpprofile(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 }

--- a/citrixadc/resource_citrixadc_lbvserver_test.go
+++ b/citrixadc/resource_citrixadc_lbvserver_test.go
@@ -322,7 +322,7 @@ func doPreChecks(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 
@@ -404,7 +404,7 @@ func testSslcertificateBindingsConfig(template string, sslcertkey string, snicer
 	log.Printf("sslcertkeyReplacement \"%v\"", sslcertkeyReplacement)
 	log.Printf("snisslcertkeysReplacement \"%v\"", snisslcertkeysReplacement)
 	retval := fmt.Sprintf(template, sslcertkeyReplacement, snisslcertkeysReplacement)
-	log.Printf(fmt.Sprintf("Full config:\n`\n%s\n`", retval))
+	log.Printf("Full config:\n`\n%s\n`", retval)
 	return retval
 }
 

--- a/citrixadc/resource_citrixadc_responderaction_test.go
+++ b/citrixadc/resource_citrixadc_responderaction_test.go
@@ -152,7 +152,7 @@ func doResponderactionPreChecks(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 
@@ -171,7 +171,7 @@ func doResponderactionPreChecks(t *testing.T) {
 	for _, page := range pages {
 		if err := c.client.ActOnResource(service.Responderhtmlpage.Type(), page, "Import"); err != nil {
 			if !strings.Contains(err.Error(), "Object already exists") {
-				t.Errorf(err.Error())
+				t.Errorf("%v", err)
 			}
 		}
 	}

--- a/citrixadc/resource_citrixadc_sslcacertgroup_sslcertkey_binding_test.go
+++ b/citrixadc/resource_citrixadc_sslcacertgroup_sslcertkey_binding_test.go
@@ -42,7 +42,7 @@ func doSslcacertgroup_sslcertkey_bindingPreChecks(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 }

--- a/citrixadc/resource_citrixadc_sslcertkey_test.go
+++ b/citrixadc/resource_citrixadc_sslcertkey_test.go
@@ -129,7 +129,7 @@ func doSslcertkeyPreChecks(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 }

--- a/citrixadc/resource_citrixadc_sslservice_sslcertkey_binding_test.go
+++ b/citrixadc/resource_citrixadc_sslservice_sslcertkey_binding_test.go
@@ -42,7 +42,7 @@ func doSslservice_sslcertkey_bindingPreChecks(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 }

--- a/citrixadc/resource_citrixadc_vpnglobal_sslcertkey_binding_test.go
+++ b/citrixadc/resource_citrixadc_vpnglobal_sslcertkey_binding_test.go
@@ -135,7 +135,7 @@ func PreCheckSslceriKey(t *testing.T) {
 	for _, filename := range uploads {
 		err := uploadTestdataFile(c, t, filename, "/var/tmp")
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("%v", err)
 		}
 	}
 }


### PR DESCRIPTION
… string for error reporting.

fix(tests): use constant format string in t.Errorf to resolve non-constant format string error

Replaced t.Errorf(err.Error()) with t.Errorf("%v", err) to comply with Go's requirement for a constant format string in t.Errorf calls.