### PR TITLE
marking filecontent as sensitive as a best practice measure

### DIFF
--- a/citrixadc/resource_citrixadc_systemfile.go
+++ b/citrixadc/resource_citrixadc_systemfile.go
@@ -33,9 +33,10 @@ func resourceCitrixAdcSystemfile() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"filecontent": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 			"fileencoding": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Files can contain SSL certificates, private keys, passwords, API tokens
this will keep file content out of Terraform logs, terraform plan/apply output 