### PR TITLE
handling int64 conversion for type float64

### DIFF
--- a/citrixadc_framework/utils/utils.go
+++ b/citrixadc_framework/utils/utils.go
@@ -24,6 +24,8 @@ func ConvertToInt64(value interface{}) (int64, error) {
 		return int64(v), nil
 	case int64:
 		return v, nil
+	case float64:
+		return int64(v), nil
 	case string:
 		return strconv.ParseInt(v, 10, 64)
 	default:


### PR DESCRIPTION
Log Messages :

2026-01-22T09:30:58.486Z [DEBUG] provider.terraform-provider-citrixadc: dbsttl - ok=true, val=0, val type=float64, val==nil=false: tf_resource_type=citrixadc_lbparameter tf_rpc=ApplyResourceChange tf_provider_addr=registry.terraform.io/citrix/citrixadc @caller=/home/lakshmj/git_repo/terraform-provider-citrixadc/citrixadc_framework/lbparameter/resource_schema.go:261 @module=citrixadc tf_mux_provider="*proto6server.Server" tf_req_id=7be2eab6-ddf2-27b6-18cc-22c16b5d29ba timestamp=2026-01-22T09:30:58.485Z
2026-01-22T09:30:58.486Z [DEBUG] provider.terraform-provider-citrixadc: Attempting to retrieve dbsttl value: 0: tf_req_id=7be2eab6-ddf2-27b6-18cc-22c16b5d29ba tf_resource_type=citrixadc_lbparameter tf_rpc=ApplyResourceChange @caller=/home/lakshmj/git_repo/terraform-provider-citrixadc/citrixadc_framework/lbparameter/resource_schema.go:262 tf_mux_provider="*proto6server.Server" tf_provider_addr=registry.terraform.io/citrix/citrixadc @module=citrixadc timestamp=2026-01-22T09:30:58.485Z
2026-01-22T09:30:58.486Z [DEBUG] provider.terraform-provider-citrixadc: dbsttl value from API: 0 (type: float64): tf_resource_type=citrixadc_lbparameter tf_rpc=ApplyResourceChange tf_mux_provider="*proto6server.Server" tf_provider_addr=registry.terraform.io/citrix/citrixadc @caller=/home/lakshmj/git_repo/terraform-provider-citrixadc/citrixadc_framework/lbparameter/resource_schema.go:264 @module=citrixadc tf_req_id=7be2eab6-ddf2-27b6-18cc-22c16b5d29ba timestamp=2026-01-22T09:30:58.485Z
2026-01-22T09:30:58.486Z [DEBUG] provider.terraform-provider-citrixadc: Before conversion - dbsttl raw value: 0: @caller=/home/lakshmj/git_repo/terraform-provider-citrixadc/citrixadc_framework/lbparameter/resource_schema.go:265 @module=citrixadc tf_rpc=ApplyResourceChange tf_mux_provider="*proto6server.Server" tf_provider_addr=registry.terraform.io/citrix/citrixadc tf_req_id=7be2eab6-ddf2-27b6-18cc-22c16b5d29ba tf_resource_type=citrixadc_lbparameter timestamp=2026-01-22T09:30:58.485Z
2026-01-22T09:30:58.486Z [DEBUG] provider.terraform-provider-citrixadc: dbsttl conversion error: cannot convert float64 to int64: @caller=/home/lakshmj/git_repo/terraform-provider-citrixadc/citrixadc_framework/lbparameter/resource_schema.go:270 @module=citrixadc tf_provider_addr=registry.terraform.io/citrix/citrixadc tf_req_id=7be2eab6-ddf2-27b6-18cc-22c16b5d29ba tf_mux_provider="*proto6server.Server" tf_resource_type=citrixadc_lbparameter tf_rpc=ApplyResourceChange timestamp=2026-01-22T09:30:58.485Z