### PR TITLE
Rectifying Id calculation logic for sslvserver_sslcertkey_binding in migration usecase.

### DIFF
--- a/citrixadc/resource_citrixadc_sslvserver_sslcertkey_binding.go
+++ b/citrixadc/resource_citrixadc_sslvserver_sslcertkey_binding.go
@@ -112,12 +112,12 @@ func readSslvserver_sslcertkey_bindingFunc(ctx context.Context, d *schema.Resour
 			ca = idSlice[3] == "true"
 		} else {
 			ca = d.Get("ca").(bool)
-			bindingId = fmt.Sprintf("%s,%t,%t", bindingId, snicert, ca)
+			bindingId = fmt.Sprintf("%s,%s,%t,%t", vservername, certkeyname, snicert, ca)
 			d.SetId(bindingId)
 		}
 	} else {
 		snicert = d.Get("snicert").(bool)
-		ca := d.Get("ca").(bool)
+		ca = d.Get("ca").(bool)
 		bindingId = fmt.Sprintf("%s,%t,%t", bindingId, snicert, ca)
 		d.SetId(bindingId)
 	}


### PR DESCRIPTION
Rectifying Id calculation logic for sslvserver_sslcertkey_binding in migration usecase.