### PR TITLE
changes for adding capability to delete default route in the netscaler 

### DIFF
--- a/citrixadc/resource_citrixadc_route.go
+++ b/citrixadc/resource_citrixadc_route.go
@@ -410,12 +410,7 @@ func deleteRouteFunc(ctx context.Context, d *schema.ResourceData, meta interface
 		argsMap["ownergroup"] = url.QueryEscape(val.(string))
 	}
 
-	err := client.DeleteResourceWithArgsMap(service.Route.Type(), "", argsMap)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Restore the original default route if delete_default_route was true
+	// Restore the original default route before deleting the managed route
 	if d.Get("delete_default_route").(bool) {
 		originalGw := d.Get("original_default_gateway").(string)
 		if originalGw != "" {
@@ -431,6 +426,11 @@ func deleteRouteFunc(ctx context.Context, d *schema.ResourceData, meta interface
 			}
 			log.Printf("[DEBUG] citrixadc-provider: Successfully restored default route with gateway %s", originalGw)
 		}
+	}
+
+	err := client.DeleteResourceWithArgsMap(service.Route.Type(), "", argsMap)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId("")

--- a/citrixadc/resource_citrixadc_route.go
+++ b/citrixadc/resource_citrixadc_route.go
@@ -112,6 +112,19 @@ func resourceCitrixAdcRoute() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"delete_default_route": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "If true, delete the default static route (network 0.0.0.0, netmask 0.0.0.0) after adding this route",
+			},
+			"original_default_gateway": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Stores the gateway of the original default route that was deleted, used to restore it on destroy",
+			},
 		},
 	}
 }
@@ -158,6 +171,45 @@ func createRouteFunc(ctx context.Context, d *schema.ResourceData, meta interface
 	_, err := client.AddResource(service.Route.Type(), route.Network, &route)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Delete default route (0.0.0.0/0.0.0.0) if delete_default_route is set
+	if d.Get("delete_default_route").(bool) {
+		log.Printf("[DEBUG] citrixadc-provider: delete_default_route is true, finding and deleting default route (0.0.0.0/0.0.0.0)")
+		findParams := service.FindParams{
+			ResourceType: service.Route.Type(),
+		}
+		dataArray, findErr := client.FindResourceArrayWithParams(findParams)
+		if findErr != nil {
+			return diag.Errorf("delete_default_route is true but failed to list routes: %s", findErr.Error())
+		}
+
+		defaultRouteFound := false
+		for _, r := range dataArray {
+			routeNetwork, _ := r["network"].(string)
+			routeNetmask, _ := r["netmask"].(string)
+			routeGateway, _ := r["gateway"].(string)
+
+			if routeNetwork == "0.0.0.0" && routeNetmask == "0.0.0.0" {
+				defaultRouteFound = true
+				log.Printf("[DEBUG] citrixadc-provider: Deleting default route with gateway %s", routeGateway)
+				delArgs := map[string]string{
+					"network": url.QueryEscape("0.0.0.0"),
+					"netmask": url.QueryEscape("0.0.0.0"),
+					"gateway": url.QueryEscape(routeGateway),
+				}
+				delErr := client.DeleteResourceWithArgsMap(service.Route.Type(), "", delArgs)
+				if delErr != nil {
+					return diag.Errorf("Error deleting default route (gateway %s): %s", routeGateway, delErr.Error())
+				}
+				log.Printf("[DEBUG] citrixadc-provider: Successfully deleted default route with gateway %s", routeGateway)
+				// Save the original gateway so we can restore it on destroy
+				d.Set("original_default_gateway", routeGateway)
+			}
+		}
+		if !defaultRouteFound {
+			log.Printf("[WARN] citrixadc-provider: delete_default_route is true but no default route (0.0.0.0/0.0.0.0) was found")
+		}
 	}
 
 	d.SetId(routeName)
@@ -361,6 +413,24 @@ func deleteRouteFunc(ctx context.Context, d *schema.ResourceData, meta interface
 	err := client.DeleteResourceWithArgsMap(service.Route.Type(), "", argsMap)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Restore the original default route if delete_default_route was true
+	if d.Get("delete_default_route").(bool) {
+		originalGw := d.Get("original_default_gateway").(string)
+		if originalGw != "" {
+			log.Printf("[DEBUG] citrixadc-provider: Restoring default route (0.0.0.0/0.0.0.0) with gateway %s", originalGw)
+			defaultRoute := network.Route{
+				Network: "0.0.0.0",
+				Netmask: "0.0.0.0",
+				Gateway: originalGw,
+			}
+			_, restoreErr := client.AddResource(service.Route.Type(), "0.0.0.0", &defaultRoute)
+			if restoreErr != nil {
+				return diag.Errorf("Error restoring default route (0.0.0.0/0.0.0.0) with gateway %s: %s", originalGw, restoreErr.Error())
+			}
+			log.Printf("[DEBUG] citrixadc-provider: Successfully restored default route with gateway %s", originalGw)
+		}
 	}
 
 	d.SetId("")

--- a/citrixadc/resource_citrixadc_route_delete_default_test.go
+++ b/citrixadc/resource_citrixadc_route_delete_default_test.go
@@ -1,0 +1,371 @@
+package citrixadc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/citrix/adc-nitro-go/service"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Test 1: Positive case - add route with delete_default_route=true, verify default route is deleted
+func TestAccRoute_delete_default_route(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDeleteDefaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute_delete_default_true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "true"),
+					resource.TestCheckResourceAttrSet("citrixadc_route.test_route", "original_default_gateway"),
+					testAccCheckDefaultRouteAbsent(),
+				),
+			},
+		},
+	})
+}
+
+// Test 2: Destroy restores default route - add route with delete_default_route=true,
+// then destroy and verify default route is restored
+func TestAccRoute_delete_default_route_restore_on_destroy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDeleteDefaultRestored,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute_delete_default_true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "true"),
+					testAccCheckDefaultRouteAbsent(),
+				),
+			},
+		},
+	})
+}
+
+// Test 3: Update mutable attribute (distance) without affecting delete_default_route
+func TestAccRoute_update_distance_preserves_delete_default(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDeleteDefaultRestored,
+		Steps: []resource.TestStep{
+			// Step 1: Create route with delete_default_route=true
+			{
+				Config: testAccRoute_delete_default_true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "true"),
+					testAccCheckDefaultRouteAbsent(),
+				),
+			},
+			// Step 2: Update distance to 3, delete_default_route stays true
+			{
+				Config: testAccRoute_delete_default_true_update_distance,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "distance", "3"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "true"),
+					resource.TestCheckResourceAttrSet("citrixadc_route.test_route", "original_default_gateway"),
+					testAccCheckDefaultRouteAbsent(),
+				),
+			},
+		},
+	})
+}
+
+// Test 4: Route with delete_default_route=false (default behavior, no default route deletion)
+func TestAccRoute_delete_default_route_false(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDestroyedGeneric,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute_delete_default_false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route_no_delete"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route_no_delete", "delete_default_route", "false"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route_no_delete", "original_default_gateway", ""),
+					testAccCheckDefaultRoutePresent(),
+				),
+			},
+		},
+	})
+}
+
+// Test 5: Route without specifying delete_default_route (defaults to false)
+func TestAccRoute_delete_default_route_omitted(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDestroyedGeneric,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute_delete_default_omitted,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route_omitted"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route_omitted", "delete_default_route", "false"),
+					testAccCheckDefaultRoutePresent(),
+				),
+			},
+		},
+	})
+}
+
+// Test 6: Changing delete_default_route from true to false forces recreate
+func TestAccRoute_delete_default_route_force_new(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteDeleteDefaultRestored,
+		Steps: []resource.TestStep{
+			// Step 1: Create with delete_default_route=true
+			{
+				Config: testAccRoute_delete_default_true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "true"),
+					testAccCheckDefaultRouteAbsent(),
+				),
+			},
+			// Step 2: Change delete_default_route to false - should force destroy+recreate
+			// The destroy will restore the default route, then create without deleting it
+			{
+				Config: testAccRoute_delete_default_changed_to_false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteExist("citrixadc_route.test_route"),
+					resource.TestCheckResourceAttr("citrixadc_route.test_route", "delete_default_route", "false"),
+					testAccCheckDefaultRoutePresent(),
+				),
+			},
+		},
+	})
+}
+
+// --- Test Configs ---
+
+const testAccRoute_delete_default_true = `
+resource "citrixadc_route" "test_route" {
+  network              = "192.168.10.0"
+  netmask              = "255.255.255.0"
+  gateway              = "10.102.126.1"
+  delete_default_route = true
+}
+`
+
+const testAccRoute_delete_default_true_update_distance = `
+resource "citrixadc_route" "test_route" {
+  network              = "192.168.10.0"
+  netmask              = "255.255.255.0"
+  gateway              = "10.102.126.1"
+  distance             = 3
+  delete_default_route = true
+}
+`
+
+const testAccRoute_delete_default_false = `
+resource "citrixadc_route" "test_route_no_delete" {
+  network              = "192.168.20.0"
+  netmask              = "255.255.255.0"
+  gateway              = "10.102.126.1"
+  delete_default_route = false
+}
+`
+
+const testAccRoute_delete_default_omitted = `
+resource "citrixadc_route" "test_route_omitted" {
+  network = "192.168.30.0"
+  netmask = "255.255.255.0"
+  gateway = "10.102.126.1"
+}
+`
+
+const testAccRoute_delete_default_changed_to_false = `
+resource "citrixadc_route" "test_route" {
+  network              = "192.168.10.0"
+  netmask              = "255.255.255.0"
+  gateway              = "10.102.126.1"
+  delete_default_route = false
+}
+`
+
+// --- Check Functions ---
+
+// testAccCheckRouteExist verifies the route exists on the NetScaler
+func testAccCheckRouteExist(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("route resource not found in state: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("route resource ID is not set")
+		}
+
+		client, err := testAccGetClient()
+		if err != nil {
+			return err
+		}
+
+		findParams := service.FindParams{
+			ResourceType: service.Route.Type(),
+		}
+		dataArray, err := client.FindResourceArrayWithParams(findParams)
+		if err != nil {
+			return fmt.Errorf("error fetching routes: %s", err.Error())
+		}
+
+		network := rs.Primary.Attributes["network"]
+		netmask := rs.Primary.Attributes["netmask"]
+		gateway := rs.Primary.Attributes["gateway"]
+
+		for _, r := range dataArray {
+			if r["network"] == network && r["netmask"] == netmask && r["gateway"] == gateway {
+				return nil
+			}
+		}
+		return fmt.Errorf("route %s/%s via %s not found on NetScaler", network, netmask, gateway)
+	}
+}
+
+// testAccCheckDefaultRouteAbsent verifies the default route (0.0.0.0/0.0.0.0) does NOT exist
+func testAccCheckDefaultRouteAbsent() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := testAccGetClient()
+		if err != nil {
+			return err
+		}
+
+		findParams := service.FindParams{
+			ResourceType: service.Route.Type(),
+		}
+		dataArray, err := client.FindResourceArrayWithParams(findParams)
+		if err != nil {
+			return fmt.Errorf("error fetching routes: %s", err.Error())
+		}
+
+		for _, r := range dataArray {
+			if r["network"] == "0.0.0.0" && r["netmask"] == "0.0.0.0" {
+				return fmt.Errorf("default route (0.0.0.0/0.0.0.0) still exists with gateway %s, expected it to be deleted", r["gateway"])
+			}
+		}
+		return nil
+	}
+}
+
+// testAccCheckDefaultRoutePresent verifies the default route (0.0.0.0/0.0.0.0) exists
+func testAccCheckDefaultRoutePresent() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := testAccGetClient()
+		if err != nil {
+			return err
+		}
+
+		findParams := service.FindParams{
+			ResourceType: service.Route.Type(),
+		}
+		dataArray, err := client.FindResourceArrayWithParams(findParams)
+		if err != nil {
+			return fmt.Errorf("error fetching routes: %s", err.Error())
+		}
+
+		for _, r := range dataArray {
+			if r["network"] == "0.0.0.0" && r["netmask"] == "0.0.0.0" {
+				return nil
+			}
+		}
+		return fmt.Errorf("default route (0.0.0.0/0.0.0.0) not found, expected it to be present")
+	}
+}
+
+// testAccCheckRouteDeleteDefaultDestroy verifies route is deleted after destroy
+func testAccCheckRouteDeleteDefaultDestroy(s *terraform.State) error {
+	client, err := testAccGetClient()
+	if err != nil {
+		return err
+	}
+
+	findParams := service.FindParams{
+		ResourceType: service.Route.Type(),
+	}
+	dataArray, err := client.FindResourceArrayWithParams(findParams)
+	if err != nil {
+		return fmt.Errorf("error fetching routes: %s", err.Error())
+	}
+
+	for _, r := range dataArray {
+		if r["network"] == "192.168.10.0" && r["netmask"] == "255.255.255.0" {
+			return fmt.Errorf("route 192.168.10.0/255.255.255.0 still exists after destroy")
+		}
+	}
+	return nil
+}
+
+// testAccCheckRouteDeleteDefaultRestored verifies route is deleted AND default route is restored after destroy
+func testAccCheckRouteDeleteDefaultRestored(s *terraform.State) error {
+	client, err := testAccGetClient()
+	if err != nil {
+		return err
+	}
+
+	findParams := service.FindParams{
+		ResourceType: service.Route.Type(),
+	}
+	dataArray, err := client.FindResourceArrayWithParams(findParams)
+	if err != nil {
+		return fmt.Errorf("error fetching routes: %s", err.Error())
+	}
+
+	// Verify the managed route is gone
+	for _, r := range dataArray {
+		if r["network"] == "192.168.10.0" && r["netmask"] == "255.255.255.0" {
+			return fmt.Errorf("route 192.168.10.0/255.255.255.0 still exists after destroy")
+		}
+	}
+
+	// Verify the default route was restored
+	for _, r := range dataArray {
+		if r["network"] == "0.0.0.0" && r["netmask"] == "0.0.0.0" {
+			return nil
+		}
+	}
+	return fmt.Errorf("default route (0.0.0.0/0.0.0.0) was not restored after destroy")
+}
+
+// testAccCheckRouteDestroyed returns a CheckDestroy func for a specific resource
+func testAccCheckRouteDestroyedGeneric(s *terraform.State) error {
+	client, err := testAccGetClient()
+	if err != nil {
+		return err
+	}
+
+	findParams := service.FindParams{
+		ResourceType: service.Route.Type(),
+	}
+	dataArray, err := client.FindResourceArrayWithParams(findParams)
+	if err != nil {
+		return fmt.Errorf("error fetching routes: %s", err.Error())
+	}
+
+	// Look up the network from the last known state
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "citrixadc_route" {
+			continue
+		}
+		network := rs.Primary.Attributes["network"]
+		netmask := rs.Primary.Attributes["netmask"]
+		for _, r := range dataArray {
+			if r["network"] == network && r["netmask"] == netmask {
+				return fmt.Errorf("route %s/%s still exists after destroy", network, netmask)
+			}
+		}
+	}
+	return nil
+}

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -18,6 +18,19 @@ resource "citrixadc_route" "tf_route" {
 }
 ```
 
+### Example usage with delete_default_route
+
+```hcl
+resource "citrixadc_route" "tf_route" {
+    network              = "192.168.10.0"
+    netmask              = "255.255.255.0"
+    gateway              = "10.0.1.1"
+    delete_default_route = true
+}
+```
+
+When `delete_default_route` is set to `true`, the default route (`0.0.0.0/0.0.0.0`) is deleted after this route is created. The original default gateway is saved in state so it can be restored when this resource is destroyed. On destroy, the original default route is restored **before** the managed route is deleted.
+
 
 ## Argument Reference
 
@@ -38,6 +51,7 @@ resource "citrixadc_route" "tf_route" {
 * `detail` - (Optional) Display a detailed view.
 * `mgmt` - (Optional) Route in management plane.
 * `protocol` - (Optional) Routing protocol used for advertising this route.
+* `delete_default_route` - (Optional) If true, delete the default static route (`0.0.0.0/0.0.0.0`) after adding this route. The original default gateway is saved in state and restored when this resource is destroyed. Defaults to `false`. Changing this value forces resource recreation.
 
 
 ## Attribute Reference
@@ -45,6 +59,7 @@ resource "citrixadc_route" "tf_route" {
 In addition to the arguments, the following attributes are available:
 
 * `id` - The id of the route. It is the conatenation of the `network`, `netmask` and `gateway` attributes.
+* `original_default_gateway` - The gateway of the original default route that was deleted when `delete_default_route` is `true`. This value is used to restore the default route on destroy.
 
 
 ## Import


### PR DESCRIPTION
…r, after adding a valid route

New attributes:

delete_default_route (bool, optional, default: false, ForceNew)
original_default_gateway (string, computed, ForceNew)
Create (terraform apply):

Add the new route (network/netmask/gateway) to NetScaler
If add fails → return error, do not touch default route
If delete_default_route = true:
Fetch all routes, find the one with [network=0.0.0.0, netmask=0.0.0.0](vscode-file://vscode-app/c:/Users/pragyaj/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Delete it
Save its gateway into original_default_gateway in state
If no default route exists → log warning, continue
Update (terraform apply with attribute changes):

delete_default_route and original_default_gateway have [ForceNew: true](vscode-file://vscode-app/c:/Users/pragyaj/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — they cannot be modified in-place
Changing delete_default_route in config triggers destroy + recreate (not an update)
Other mutable attributes (e.g., distance, weight, advertise) update normally without affecting the default route
Delete (terraform destroy):

Delete the managed route from NetScaler
If delete_default_route was true and original_default_gateway is saved in state:
Re-add the default route (0.0.0.0/0.0.0.0) with the original gateway
Device is restored to its original routing state