### PR TITLE
creating a two node cluster is leading to panic mode

### DIFF
--- a/citrixadc/resource_citrixadc_cluster.go
+++ b/citrixadc/resource_citrixadc_cluster.go
@@ -894,6 +894,10 @@ func createFirstClusterNode(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if len(data) == 0 {
+		return fmt.Errorf("No cluster nodes found after bootstrap. The CLIP may not be fully ready yet.")
+	}
+
 	fetchedIpaddress := data[0]["ipaddress"]
 	configIpaddress := firstNode["ipaddress"]
 	if fetchedIpaddress != configIpaddress {
@@ -1688,6 +1692,10 @@ func pollNode(d *schema.ResourceData, meta interface{}, timeout time.Duration) e
 		}
 	} else {
 		log.Printf("Status code is %v\n", resp.Status)
+		if resp.StatusCode != 200 {
+			log.Printf("[DEBUG] netscaler-provider: pollNode got non-200 status %d, treating as unreachable", resp.StatusCode)
+			return fmt.Errorf("Timeout")
+		}
 	}
 	// No error
 	return nil


### PR DESCRIPTION
2026-04-16T09:45:41.641Z [DEBUG] provider.terraform-provider-citrixadc: 2026/04/16
09:45:41 [DEBUG] netscaler-provider: In resourceClusterPoll
2026-04-16T09:45:41.641Z [DEBUG] provider.terraform-provider-citrixadc: 2026/04/16
09:45:41 [DEBUG] netscaler-provider: In pollLicense
2026-04-16T09:45:43.214Z [DEBUG] provider.terraform-provider-citrixadc: 2026/04/16
09:45:43 Status code is 503 Service Unavailable
2026-04-16T09:45:43.214Z [DEBUG] provider.terraform-provider-citrixadc: 2026/04/16
09:45:43 [DEBUG] netscaler-provider: Cluster poll result "cluster_reachable"
2026-04-16T09:45:43.711Z [ERROR] provider.terraform-provider-citrixadc: panic:
runtime error: index out of range [0] with length 0

The 503 was treated as reachable, which led to the panic