### PR TITLE
add http2smallwndtimeout parameter

### DIFF
--- a/citrixadc/resource_citrixadc_nshttpprofile.go
+++ b/citrixadc/resource_citrixadc_nshttpprofile.go
@@ -323,6 +323,11 @@ func resourceCitrixAdcNshttpprofile() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"http2smallwndtimeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -453,6 +458,9 @@ func createNshttpprofileFunc(ctx context.Context, d *schema.ResourceData, meta i
 	if raw := d.GetRawConfig().GetAttr("maxduplicateheaderfields"); !raw.IsNull() {
 		nshttpprofile.Maxduplicateheaderfields = intPtr(d.Get("maxduplicateheaderfields").(int))
 	}
+	if raw := d.GetRawConfig().GetAttr("http2smallwndtimeout"); !raw.IsNull() {
+		nshttpprofile.Http2smallwndtimeout = intPtr(d.Get("http2smallwndtimeout").(int))
+	}
 
 	_, err := client.AddResource(service.Nshttpprofile.Type(), nshttpprofileName, &nshttpprofile)
 	if err != nil {
@@ -536,6 +544,7 @@ func readNshttpprofileFunc(ctx context.Context, d *schema.ResourceData, meta int
 	setToInt("maxduplicateheaderfields", d, data["maxduplicateheaderfields"])
 	d.Set("passprotocolupgrade", data["passprotocolupgrade"])
 	d.Set("http2extendedconnect", data["http2extendedconnect"])
+	setToInt("http2smallwndtimeout", d, data["http2smallwndtimeout"])
 
 	return nil
 
@@ -848,6 +857,11 @@ func updateNshttpprofileFunc(ctx context.Context, d *schema.ResourceData, meta i
 	if d.HasChange("http2extendedconnect") {
 		log.Printf("[DEBUG]  citrixadc-provider: Http2extendedconnect has changed for nshttpprofile %s, starting update", nshttpprofileName)
 		nshttpprofile.Http2extendedconnect = d.Get("http2extendedconnect").(string)
+		hasChange = true
+	}
+	if d.HasChange("http2smallwndtimeout") {
+		log.Printf("[DEBUG]  citrixadc-provider: Http2smallwndtimeout has changed for nshttpprofile %s, starting update", nshttpprofileName)
+		nshttpprofile.Http2smallwndtimeout = intPtr(d.Get("http2smallwndtimeout").(int))
 		hasChange = true
 	}
 

--- a/citrixadc_framework/acctests/nshttpprofile_test.go
+++ b/citrixadc_framework/acctests/nshttpprofile_test.go
@@ -41,6 +41,7 @@ const testAccNshttpprofile_add = `
 		maxduplicateheaderfields = 10
 		passprotocolupgrade = "DISABLED"
 		http2extendedconnect = "DISABLED"
+		http2smallwndtimeout = 30
 	}
 `
 const testAccNshttpprofile_update = `
@@ -60,6 +61,7 @@ const testAccNshttpprofile_update = `
 		maxduplicateheaderfields = 12
 		passprotocolupgrade = "ENABLED"
 		http2extendedconnect = "ENABLED"
+		http2smallwndtimeout = 60
 	}
 `
 
@@ -88,6 +90,7 @@ func TestAccNshttpprofile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "maxduplicateheaderfields", "10"),
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "passprotocolupgrade", "DISABLED"),
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "http2extendedconnect", "DISABLED"),
+					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "http2smallwndtimeout", "30"),
 				),
 			},
 			{
@@ -109,6 +112,7 @@ func TestAccNshttpprofile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "maxduplicateheaderfields", "12"),
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "passprotocolupgrade", "ENABLED"),
 					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "http2extendedconnect", "ENABLED"),
+					resource.TestCheckResourceAttr("citrixadc_nshttpprofile.foo", "http2smallwndtimeout", "60"),
 				),
 			},
 		},

--- a/citrixadc_framework/nshttpprofile/datasource_schema.go
+++ b/citrixadc_framework/nshttpprofile/datasource_schema.go
@@ -155,6 +155,11 @@ func NshttpprofileDataSourceSchema() schema.Schema {
 				Computed:    true,
 				Description: "Maximum number of incoming RST_STREAM frames allowed in HTTP/2 connection per minute",
 			},
+			"http2smallwndtimeout": schema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Timeout (in seconds) for HTTP/2 small-window stalled streams. Required to mitigate CVE-2026-13474.",
+			},
 			"http2maxsettingsframespermin": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,

--- a/citrixadc_framework/nshttpprofile/resource_schema.go
+++ b/citrixadc_framework/nshttpprofile/resource_schema.go
@@ -49,6 +49,7 @@ type NshttpprofileResourceModel struct {
 	Http2maxrxresetframespermin      types.Int64  `tfsdk:"http2maxrxresetframespermin"`
 	Http2maxsettingsframespermin     types.Int64  `tfsdk:"http2maxsettingsframespermin"`
 	Http2minseverconn                types.Int64  `tfsdk:"http2minseverconn"`
+	Http2smallwndtimeout             types.Int64  `tfsdk:"http2smallwndtimeout"`
 	Http2strictcipher                types.String `tfsdk:"http2strictcipher"`
 	Http3                            types.String `tfsdk:"http3"`
 	Http3maxheaderblockedstreams     types.Int64  `tfsdk:"http3maxheaderblockedstreams"`
@@ -232,6 +233,11 @@ func (r *NshttpprofileResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:    true,
 				Computed:    true,
 				Description: "Maximum number of incoming RST_STREAM frames allowed in HTTP/2 connection per minute",
+			},
+			"http2smallwndtimeout": schema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Timeout (in seconds) for HTTP/2 small-window stalled streams. Required to mitigate CVE-2026-13474.",
 			},
 			"http2maxsettingsframespermin": schema.Int64Attribute{
 				Optional:    true,
@@ -754,6 +760,13 @@ func nshttpprofileSetAttrFromGet(ctx context.Context, data *NshttpprofileResourc
 		}
 	} else {
 		data.Http2maxrxresetframespermin = types.Int64Null()
+	}
+	if val, ok := getResponseData["http2smallwndtimeout"]; ok && val != nil {
+		if intVal, err := utils.ConvertToInt64(val); err == nil {
+			data.Http2smallwndtimeout = types.Int64Value(intVal)
+		}
+	} else {
+		data.Http2smallwndtimeout = types.Int64Null()
 	}
 	if val, ok := getResponseData["http2maxsettingsframespermin"]; ok && val != nil {
 		if intVal, err := utils.ConvertToInt64(val); err == nil {

--- a/docs/resources/nshttpprofile.md
+++ b/docs/resources/nshttpprofile.md
@@ -80,6 +80,7 @@ resource "citrixadc_nshttpprofile" "tf_httpprofile" {
 * `maxduplicateheaderfields` - (Optional) Maximum number of allowed occurrences of header fields that share the same field name. This threshold is enforced only for well-known header field names recognized by NetScaler. If the value is set to 0, then it will be similar to previous behavior, Where we store only 15 duplicate headers and rest are parsed and send to the server.
 * `passprotocolupgrade` - (Optional) Pass protocol upgrade request to the server.
 * `http2extendedconnect` - (Optional) Choose whether to enable HTTP/2 Extended CONNECT mechanism.
+* `http2smallwndtimeout` - (Optional) Timeout (in seconds) for HTTP/2 small-window stalled streams. Configure this parameter to mitigate CVE-2026-13474.
 
 ## Attribute Reference
 

--- a/vendor/github.com/citrix/adc-nitro-go/resource/config/ns/nshttpprofile.go
+++ b/vendor/github.com/citrix/adc-nitro-go/resource/config/ns/nshttpprofile.go
@@ -264,6 +264,10 @@ type Nshttpprofile struct {
 	* Choose whether to enable HTTP/2 Extended CONNECT mechanism.
 	*/
 	Http2extendedconnect string `json:"http2extendedconnect,omitempty"`
+	/**
+	* Timeout (in seconds) for HTTP/2 small-window stalled streams. Required to mitigate CVE-2026-13474.
+	*/
+	Http2smallwndtimeout *int `json:"http2smallwndtimeout,omitempty"`
 
 	//------- Read only Parameter ---------;
 


### PR DESCRIPTION
add http2smallwndtimeout parameter for CVE-2026-13474

Adds support for the http2SmallWndTimeout parameter introduced in
NetScaler firmware 14.1-72.61 as part of the security fix for
CVE-2026-13474. This parameter controls the timeout (in seconds) for
HTTP/2 small-window stalled streams and must be configured to mitigate
the vulnerability.

Changes:
- vendor/adc-nitro-go: add Http2smallwndtimeout field to Nshttpprofile
  struct so it is included in NITRO API request payloads
- citrixadc/resource_citrixadc_nshttpprofile.go: schema, create, read,
  and update support (SDKv2 resource)
- citrixadc_framework/nshttpprofile/resource_schema.go: model struct
  field, schema attribute, and read-back in nshttpprofileSetAttrFromGet
  (Plugin Framework resource)
- citrixadc_framework/nshttpprofile/datasource_schema.go: schema
  attribute (Plugin Framework datasource)
- citrixadc_framework/acctests/nshttpprofile_test.go: acceptance test
  coverage for create (value=30) and update (value=60)
- docs/resources/nshttpprofile.md: parameter documentation

Tested against NetScaler 