### PR TITLE
password is masked in the logs

### DIFF
--- a/citrixadc/resource_citrixadc_cluster.go
+++ b/citrixadc/resource_citrixadc_cluster.go
@@ -1644,7 +1644,10 @@ func instantiateNodeClient(d *schema.ResourceData, meta interface{}, nodeMap map
 		Timeout:     meta.(*NetScalerNitroClient).NsTimeout,
 	}
 
-	log.Printf("[DEBUG]  citrixadc-provider: node client params %v", params)
+	// Shallow-copy params and mask the password so it never lands in logs in clear text.
+	safeParams := params
+	safeParams.Password = "****"
+	log.Printf("[DEBUG]  citrixadc-provider: node client params %+v", safeParams)
 
 	nodeClient, err := service.NewNitroClientFromParams(params)
 	return nodeClient, err

--- a/citrixadc/resource_citrixadc_cluster.go
+++ b/citrixadc/resource_citrixadc_cluster.go
@@ -741,7 +741,9 @@ func createFirstClusterNode(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG]  citrixadc-provider: first node client %v", nodeClient)
+	// Log only the client's URL, not the whole struct: %v on *NitroClient prints its
+	// unexported password field in clear text.
+	log.Printf("[DEBUG]  citrixadc-provider: first node client for url %s", nodeClient.GetURL())
 
 	clid := d.Get("clid").(int)
 	clusterId := strconv.Itoa(clid)


### PR DESCRIPTION
Mask the ADC password in the cluster node-client debug log by logging a copy of NitroParams with Password replaced by ****, preventing credentials from leaking into Terraform debug logs.